### PR TITLE
taskcat GitHub Action MVP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM taskcat/taskcat
 
-ENTRYPOINT [ "taskcat", "test", "run" ]
+ENTRYPOINT /bin/sh -c "taskcat test run | cat"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM taskcat/taskcat
+
+ENTRYPOINT [ "taskcat", "test", "run" ]

--- a/action.yaml
+++ b/action.yaml
@@ -4,4 +4,4 @@ description: Run taskcat against AWS CloudFormation templates.
 
 runs:
   using: docker
-  image: taskcat/taskcat:latest
+  image: ./Dockerfile

--- a/action.yaml
+++ b/action.yaml
@@ -2,14 +2,6 @@
 name: taskcat
 description: Run taskcat against AWS CloudFormation templates.
 
-inputs:
-  aws-action-key-id:
-    description: AWS Access Key id
-    required: true
-  aws-secret-action-key:
-    description: AWS Secret Access Key
-    required: true
-
 runs:
   using: docker
   image: taskcat/taskcat:latest

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,15 @@
+---
+name: taskcat
+description: Run taskcat against AWS CloudFormation templates.
+
+inputs:
+  aws-action-key-id:
+    description: AWS Access Key id
+    required: true
+  aws-secret-action-key:
+    description: AWS Secret Access Key
+    required: true
+
+runs:
+  using: docker
+  image: taskcat/taskcat:latest


### PR DESCRIPTION
> ⚠️ This pull request is a copy of #7 – that PR was reverted by #8 because the rebase into `develop` invalidated the commit GPG signatures

Minimum viable product for the taskcat GitHub Action. This action can be used in CI/CD pipelines to test the deployment of AWS CloudFormation templates.

This pull request introduces the ability to run [taskcat](github.com/aws-quickstart/taskcat) from GitHub Actions, and locally using [act](https://github.com/nektos/act). Unit tests will be introduced in a future pull request.

This pull request closes #1 

# Running taskcat using GitHub Actions
![image](https://user-images.githubusercontent.com/5815058/78086624-8576ea00-738c-11ea-9361-20535c32aff8.png)

# Running taskcat using act
[![asciicast](https://asciinema.org/a/314778.svg)](https://asciinema.org/a/314778)