### PR TITLE
fix(docker): set pipefail to catch taskcat errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM taskcat/taskcat
 
-ENTRYPOINT /bin/sh -c "taskcat test run | cat"
+ENTRYPOINT /bin/sh -c "set -euo pipefail && taskcat test run | cat"


### PR DESCRIPTION
As part of #5, taskcat output is piped to `cat` to trick reprint into disabling multi-line output and enable act tests.

However, because `cat` is the last command in the pipeline, the GitHub Action always exits with return code 0, even if tasckat's execution fails. As a result, commands relying on exit codes to detect failures do not behave as expected.

A blog post from Tom Van Eyck outlines the `-o pipefail` option, which immediately fails shell scripts on pipeline errors. We also set other shell options which make Bash scripting easier and safer. See https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/ for more details.

Note that the `-x` option was not set, as it can expose secrets set in variables.

This pull request fixes #10