### PR TITLE
bugfix/act-container - use act-runner test image and fix integration tests

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,1 +1,1 @@
--P ubuntu-latest=nektos/act-environments-ubuntu:18.04
+--platform ubuntu-latest=shahradr/act-runner:latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,8 +9,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install nektos/act
         run: curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
-      - name: Pull act Docker image
-        run: docker pull nektos/act-environments-ubuntu:18.04
       - uses: actions/setup-java@v1
         with:
           java-version: 1.8

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
+      - uses: actions/setup-node@v2-beta
       - name: set PY
         run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
       - uses: actions/cache@v1

--- a/src/test/java/TasckatActionTestCase.java
+++ b/src/test/java/TasckatActionTestCase.java
@@ -14,10 +14,10 @@ public class TasckatActionTestCase {
     throws IOException {
     ProcessBuilder pBuilder = new ProcessBuilder(
       "act",
-      "--workflows",
-      "./src/test/resources/workflows/",
       "--job",
-      "taskcat"
+      "taskcat",
+      "--directory",
+      "./src/test/resources/default/"
     );
     pBuilder.redirectErrorStream(true);
     Process process = pBuilder.start();

--- a/src/test/resources/default/.github/workflows/main.yaml
+++ b/src/test/resources/default/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: set PY
         run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
       - name: taskcat
-        uses: ./
+        uses: ./../../../../
         env:
           AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}

--- a/src/test/resources/default/.taskcat.yml
+++ b/src/test/resources/default/.taskcat.yml
@@ -1,0 +1,10 @@
+---
+project:
+  name: action-taskcat-default
+  owner: shahrad@rezaei.io
+
+tests:
+  default:
+    template: templates/dummyStack.yaml
+    regions:
+      - ca-central-1

--- a/src/test/resources/default/templates/dummyStack.yaml
+++ b/src/test/resources/default/templates/dummyStack.yaml
@@ -1,0 +1,16 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: |
+  Dummy CloudFormation template used with taskcat test scenarios. This
+  template attempts to create a dummy resource, but the condition is always
+  false - as such, this template never creates anything.
+
+Conditions:
+  AlwaysFalse:
+    Fn::Equals: [true, false]
+
+Resources:
+  DummyResource:
+    Type: Custom::DummyResource
+    Condition: AlwaysFalse

--- a/src/test/resources/workflows/main.yaml
+++ b/src/test/resources/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
       - name: set PY
         run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
       - name: taskcat


### PR DESCRIPTION
This pull request resolves build issues encountered after JUnit tests were introduced to the project.

# Using the `shahradr/act-runner` image
When running tests on GitHub-hosted runners using the [nektos/act-environments-ubuntu](https://hub.docker.com/r/nektos/act-environments-ubuntu) image, workflows would fail because the Docker image was larger than the space available to the VM hosting the runner.

The [shahradr/act-runner](https://hub.docker.com/r/shahradr/act-runner) Docker image was created to provide a smaller image for `act` tests – currently, the tools installed on the image are limited to those required by the `action-taskcat` tests.

The image itself is defined in the [ShahradR/act-test-runner-container](https://github.com/ShahradR/act-test-runner-container) repository. See ShahradR/action-taskcat#14 for details on the issue itself.

# Fix integration test resources
To support integration tests, test `taskcat` projects are created under the `src/resources/` directory. The first of these, `default`, contains a dummy CloudFormation template supported by a test workflow which invokes the `action-taskcat` GitHub Action. The `act` JUnit tests run against those directories.

```
action-taskcat/
└── src/resources/default
    ├── .github/workflows/
    │   └── main.yaml
    ├── templates
    │   └── dummyStack.yaml
    └── .taskcat.yml
```

Fixes ShahradR/action-taskcat#14