### PR TITLE
feat(taskcat): allow arbitrary taskcat commands to be ran

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,6 +23,9 @@ jobs:
           java-version: 1.8
       - name: Run the Maven verify phase
         run: mvn -B verify --file pom.xml
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   release:
     name: Create release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM taskcat/taskcat
-
-ENTRYPOINT /bin/sh -c "set -euo pipefail && taskcat test run | cat"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
       - name: Run taskcat test run
         uses: ShahradR/action-taskcat@v1
         with:
-          command: taskcat test run
+          command: test run
 ```
 
 ## Managing credentials

--- a/action.yaml
+++ b/action.yaml
@@ -1,7 +1,24 @@
 ---
 name: taskcat
-description: Run taskcat against AWS CloudFormation templates.
+author: Shahrad Rezaei
+description: |
+  The unofficial GitHub Action to run taskcat tests and validate your AWS
+  CloudFormation templates by deploying them in different AWS regions and
+  availability zones.
+
+inputs:
+  commands:
+    description: |
+      Command, subcommands, and arguments to pass to taskcat. Should be
+      formatted as "[args] <command> [args] [subcommand] [args]". The taskcat
+      invocation itself is already handled by the action-no need to prefix the
+      command with "taskcat".
+    required: true
 
 runs:
   using: docker
-  image: ./Dockerfile
+  image: docker://taskcat/taskcat:latest
+  entrypoint:
+    - /bin/sh
+    - -c
+    - ${{ format('taskcat {0}', inputs.commands) }}

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.1</version>
+          <configuration>
+            <systemPropertyVariables>
+              <awsAccessKeyId>${env.AWS_ACCESS_KEY_ID}</awsAccessKeyId>
+              <awsSecretAccessKey>${env.AWS_SECRET_ACCESS_KEY}</awsSecretAccessKey>
+            </systemPropertyVariables>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>

--- a/src/test/java/TasckatActionTestCase.java
+++ b/src/test/java/TasckatActionTestCase.java
@@ -79,4 +79,36 @@ public class TasckatActionTestCase {
 
     Assert.assertEquals(0, process.exitValue());
   }
+
+  @Test
+  public void test_when_no_commands_then_print_help()
+    throws IOException, InterruptedException {
+
+    ProcessBuilder pBuilder = new ProcessBuilder(
+      "act",
+      "--job",
+      "taskcat",
+      "--directory",
+      "./src/test/resources/help/"
+    );
+    pBuilder.redirectErrorStream(true);
+    Process process = pBuilder.start();
+
+    // Prevent the "java.lang.IllegalThreadStateException: process hasn't exited"
+    // exception from being thrown.
+    process.waitFor(15, TimeUnit.MINUTES);
+
+    String output = new BufferedReader(
+      new InputStreamReader(process.getInputStream())
+    )
+      .lines()
+      .collect(Collectors.joining("\n"));
+
+    assertThat(
+      output,
+      containsString("taskcat is a tool that tests AWS CloudFormation templates.")
+    );
+
+    Assert.assertEquals(0, process.exitValue());
+  }
 }

--- a/src/test/java/TasckatActionTestCase.java
+++ b/src/test/java/TasckatActionTestCase.java
@@ -35,4 +35,39 @@ public class TasckatActionTestCase {
 
     Assert.assertEquals(1, process.exitValue());
   }
+
+  @Test
+  public void test_when_creds_are_available_then_create_cfn()
+    throws IOException {
+
+    String awsAccessKeyId = System.getProperty("awsAccessKeyId");
+    String awsSecretAccessKey = System.getProperty("awsSecretAccessKey");
+
+    ProcessBuilder pBuilder = new ProcessBuilder(
+      "act",
+      "--job",
+      "taskcat",
+      "--directory",
+      "./src/test/resources/default/",
+      "--secret",
+      "AWS_ACCESS_KEY_ID=" + awsAccessKeyId,
+      "--secret",
+      "AWS_SECRET_ACCESS_KEY=" + awsSecretAccessKey
+    );
+    pBuilder.redirectErrorStream(true);
+    Process process = pBuilder.start();
+
+    String output = new BufferedReader(
+      new InputStreamReader(process.getInputStream())
+    )
+      .lines()
+      .collect(Collectors.joining("\n"));
+
+    assertThat(
+      output,
+      containsString("CREATE_COMPLETE")
+    );
+
+    Assert.assertEquals(0, process.exitValue());
+  }
 }

--- a/src/test/java/TasckatActionTestCase.java
+++ b/src/test/java/TasckatActionTestCase.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.*;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.junit.*;
 
@@ -11,7 +12,7 @@ public class TasckatActionTestCase {
 
   @Test
   public void test_when_creds_are_missing_then_throw_NoCredentialsError()
-    throws IOException {
+    throws IOException, InterruptedException {
     ProcessBuilder pBuilder = new ProcessBuilder(
       "act",
       "--job",
@@ -21,6 +22,10 @@ public class TasckatActionTestCase {
     );
     pBuilder.redirectErrorStream(true);
     Process process = pBuilder.start();
+
+    // Prevent the "java.lang.IllegalThreadStateException: process hasn't exited"
+    // exception from being thrown.
+    process.waitFor(15, TimeUnit.MINUTES);
 
     String output = new BufferedReader(
       new InputStreamReader(process.getInputStream())
@@ -38,7 +43,7 @@ public class TasckatActionTestCase {
 
   @Test
   public void test_when_creds_are_available_then_create_cfn()
-    throws IOException {
+    throws IOException, InterruptedException {
 
     String awsAccessKeyId = System.getProperty("awsAccessKeyId");
     String awsSecretAccessKey = System.getProperty("awsSecretAccessKey");
@@ -56,6 +61,10 @@ public class TasckatActionTestCase {
     );
     pBuilder.redirectErrorStream(true);
     Process process = pBuilder.start();
+
+    // Prevent the "java.lang.IllegalThreadStateException: process hasn't exited"
+    // exception from being thrown.
+    process.waitFor(15, TimeUnit.MINUTES);
 
     String output = new BufferedReader(
       new InputStreamReader(process.getInputStream())

--- a/src/test/resources/default/.github/workflows/main.yaml
+++ b/src/test/resources/default/.github/workflows/main.yaml
@@ -17,6 +17,8 @@ jobs:
         run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
       - name: taskcat
         uses: ./../../../../
+        with:
+          commands: test run
         env:
           AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}

--- a/src/test/resources/help/.github/workflows/main.yaml
+++ b/src/test/resources/help/.github/workflows/main.yaml
@@ -16,4 +16,4 @@ jobs:
       - name: taskcat
         uses: ./../../../../
         with:
-          command: taskcat
+          commands: "--help"

--- a/src/test/resources/help/.github/workflows/main.yaml
+++ b/src/test/resources/help/.github/workflows/main.yaml
@@ -1,0 +1,19 @@
+---
+on: [push]
+
+jobs:
+  taskcat:
+    runs-on: ubuntu-latest
+    name: taskcat
+    # Cannot use GitHub Action's "services" feature due to an issue in act. See nektos/act#173 for more details.
+    # services:
+    #   moto:
+    #     image: motoserver/moto
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: taskcat
+        uses: ./../../../../
+        with:
+          command: taskcat

--- a/src/test/resources/help/.taskcat.yml
+++ b/src/test/resources/help/.taskcat.yml
@@ -1,0 +1,10 @@
+---
+project:
+  name: action-taskcat-default
+  owner: shahrad@rezaei.io
+
+tests:
+  default:
+    template: templates/dummyStack.yaml
+    regions:
+      - ca-central-1

--- a/src/test/resources/help/templates/dummyStack.yaml
+++ b/src/test/resources/help/templates/dummyStack.yaml
@@ -1,0 +1,16 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: |
+  Dummy CloudFormation template used with taskcat test scenarios. This
+  template attempts to create a dummy resource, but the condition is always
+  false - as such, this template never creates anything.
+
+Conditions:
+  AlwaysFalse:
+    Fn::Equals: [true, false]
+
+Resources:
+  DummyResource:
+    Type: Custom::DummyResource
+    Condition: AlwaysFalse


### PR DESCRIPTION
This pull request allows users to run any taskcat command by using the new `commands` input parameter when using this action. Previously, the Dockerfile was hard-coded to run `taskcat test run`.

This was accomplished by eliminating the local Dockerfile altogether, in favor of the [official taskcat container image from Docker Hub](https://hub.docker.com/r/taskcat/taskcat). The entrypoint is overriden in the `action.yaml` file, where the commands specified in the action's input are passed to taskcat.

Closes: ShahradR/action-taskcat#20