### PR TITLE
fix(action): update action to meet publish rules

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,10 +1,13 @@
 ---
-name: taskcat
+name: Run taskcat tests
 author: Shahrad Rezaei
 description: |
   The unofficial GitHub Action to run taskcat tests and validate your AWS
-  CloudFormation templates by deploying them in different AWS regions and
-  availability zones.
+  CloudFormation templates
+
+branding:
+  icon: check-square
+  color: green
 
 inputs:
   commands:


### PR DESCRIPTION
Update the `action.yaml` file to meet the GitHub Marketplace publishing requirements.

Specifically:
- Rename the GitHub Action to something other than "taskcat", which is being used as an [organization name](https://github.com/taskcat)
- Shorten the description so it doesn't exceed 125 characters
- Set a brand icon and color

Associated issue: ShahradR/action-taskcat#23, ShahradR/action-taskcat#24