### PR TITLE
docs: update example to use `commands` as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
       - name: Run taskcat test run
         uses: ShahradR/action-taskcat@v1
         with:
-          command: test run
+          commands: test run
 ```
 
 ## Managing credentials


### PR DESCRIPTION
Update the example in the README.md file to use `commands` instead of `command`, and reflect the input expected by the taskcat action.

Associated issue: ShahradR/action-taskcat#28