### PR TITLE
fix(action): re-introduce a custom Dockerfile to handle user input

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,10 +27,27 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+  integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+      - name: Invoke "taskcat test run"
+        uses: ./
+        with:
+          commands: test run --project-root ./src/test/resources/default
+
   release:
     name: Create release
     runs-on: ubuntu-latest
-    needs: [pre-commit, tests]
+    needs: [pre-commit, tests, integration]
     if: ${{ needs.pre-commit.result == 'success' && needs.tests.result == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# For v0.9 and higher, the taskcat containers do not pin specific
+# versions. Rather, they always fetch the latest version from pip. See
+# https://dockr.ly/2BjpG7C to see the taskcat Dockerfile.
+
+# hadolint disable=DL3007
+FROM taskcat/taskcat:latest
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yaml
+++ b/action.yaml
@@ -20,5 +20,6 @@ inputs:
 
 runs:
   using: docker
-  image: docker://taskcat/taskcat:latest
-  entrypoint: ${{ format('/bin/sh -c taskcat {0}', inputs.commands) }}
+  image: Dockerfile
+  args:
+    - ${{ inputs.commands }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+taskcat $@

--- a/src/test/java/TasckatActionTestCase.java
+++ b/src/test/java/TasckatActionTestCase.java
@@ -11,7 +11,6 @@ import org.junit.*;
 public class TasckatActionTestCase {
 
   @Test
-  @Ignore
   public void test_when_creds_are_missing_then_throw_NoCredentialsError()
     throws IOException, InterruptedException {
     ProcessBuilder pBuilder = new ProcessBuilder(
@@ -43,7 +42,6 @@ public class TasckatActionTestCase {
   }
 
   @Test
-  @Ignore
   public void test_when_creds_are_available_then_create_cfn()
     throws IOException, InterruptedException {
 
@@ -83,7 +81,6 @@ public class TasckatActionTestCase {
   }
 
   @Test
-  @Ignore
   public void test_when_no_commands_then_print_help()
     throws IOException, InterruptedException {
 


### PR DESCRIPTION
This pull request re-introduces the project-specific `Dockerfile` and `entrypoint.sh` files, due to the complexity of maintaining Docker parameters solely in the `action.yaml` file.

Specifically, the `entrypoint` parameter is no longer defined as part of the `action.yaml` file—instead, layers are created on top of the [`taskcat/taskcat:latest`](https://hub.docker.com/r/taskcat/taskcat) image to set the entrypoint to the `entrypoint.sh` script. The script handles input tokenization, allowing users to pass commands like `test run`, like they would in the command-line version of taskcat.

Because we no longer define the entrypoint using the metadata syntax for GitHub Actions, we're side-stepping issue ShahradR/action-taskcat#26, where act and the GitHub hosted runner both expect different types for `entrypoint`. As such, we can re-enable the act JUnit tests. To prevent this in the future, and catch errors act might have missed, a job is added to the CI/CD workflow, running this action on GitHub hosted runners as part of the integration tests.

Closes ShahradR/action-taskcat#20, ShahradR/action-taskcat#26