### PR TITLE
docs: add link to official taskcat repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The unofficial GitHub Action to run [taskcat] tests and validate your AWS CloudFormation templates by deploying them in different AWS regions and availability zones!
 
+> Looking for the official taskcat project? Check out the [aws-quickstart/taskcat][taskcat] repository! This repository covers issues and work relating specifically to the GitHub Action running taskcat.
+
 ## Usage
 
 To use this action, configure your workflow and repository to ensure that:


### PR DESCRIPTION
Update the README to include a link to the [aws-quickstart/taskcat](https://github.com/aws-quickstart/taskcat) repository, redirecting users who might be looking for the official taskcat project, as opposed to this GitHub Action's code.

Closes: ShahradR/action-taskcat#34