### PR TITLE
feature/sonarcloud: add SonarCloud support to the project

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,6 +11,19 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v2.0.0
 
+  sonarcloud:
+    runs-on: ubuntu-latest
+    name: SonarCloud
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   tests:
     name: Jest tests
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # action-taskcat
 
-[![Tests](https://img.shields.io/github/workflow/status/ShahradR/action-taskcat/CI%20workflow?logo=github)](https://github.com/ShahradR/action-taskcat/actions?query=workflow%3ATests) [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit) [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+[![Tests](https://img.shields.io/github/workflow/status/ShahradR/action-taskcat/CI%20workflow?logo=github)](https://github.com/ShahradR/action-taskcat/actions?query=workflow%3ATests) [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit) [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ShahradR_action-taskcat&metric=alert_status)](https://sonarcloud.io/dashboard?id=ShahradR_action-taskcat)
 
 The unofficial GitHub Action to run [taskcat] tests and validate your AWS CloudFormation templates by deploying them in different AWS regions and availability zones!
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,4 @@
+sonar.organization=shahradr
+sonar.projectKey=ShahradR_action-taskcat
+
+sonar.sources=./src/


### PR DESCRIPTION
Add support for [SonarCloud](https://sonarcloud.io/), the hosted version of SonarQube, to "eliminate bugs and vulnerabilities" and "champion quality code in your projects."

This commit adds a `sonar-project.properties` file to configure this repository to push data to the SonarCloud project hosted at https://sonarcloud.io/dashboard?id=ShahradR_action-taskcat. The [SonarCloud GitHub Action](https://github.com/SonarSource/sonarcloud-github-action) then uses that configuration file to scan and analyze the repository's code on commits and pull requests.