### PR TITLE
fix: copy post-entrypoint script to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,6 @@ RUN apk add --no-cache nodejs=12.18.4-r0 npm=12.18.4-r0 && rm -rf /var/cache/apk
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+COPY dist/index.js /dist/index.js
+
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Copy the `dist/index.js` post-entrypoint script to the Docker container. When this action is invoked from other repositories, the runner cannot find the script and fails with an error.

Integration tests pass because the file is included in this project, and is automatically copied to the container.

Associated issue: ShahradR/action-taskcat#47