### PR TITLE
fix: set post-entrypoint script to filesystem root

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -23,4 +23,4 @@ runs:
   image: Dockerfile
   args:
     - ${{ inputs.commands }}
-  post-entrypoint: dist/index.js
+  post-entrypoint: /dist/index.js


### PR DESCRIPTION
Update the `action.yaml` file to look for the post-entrypoint script at the root of the Docker container's filesystem, reflecting the changes made to the Dockerfile.

Associated issue: ShahradR/action-taskcat#47