### PR TITLE
feat: add action input param to upgrade taskcat

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,8 +52,8 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  integration:
-    name: Integration tests
+  integration-default:
+    name: Integration tests - default
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -68,6 +68,24 @@ jobs:
         uses: ./
         with:
           commands: test run --project-root ./e2e/resources/default
+
+  integration-update:
+    name: Integration tests - update taskcat
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+      - name: Invoke "taskcat test run"
+        uses: ./
+        with:
+          commands: test run --project-root ./e2e/resources/default
+          update_taskcat: true
 
   vale:
     name: Run Vale
@@ -84,7 +102,7 @@ jobs:
   release:
     name: Create release
     runs-on: ubuntu-latest
-    needs: [pre-commit, tests, integration, vale]
+    needs: [pre-commit, tests, integration-default, integration-update, vale]
     if: ${{ needs.pre-commit.result == 'success' && needs.tests.result == 'success' && needs.integration.result == 'success' && needs.vale.result == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yaml
+++ b/action.yaml
@@ -17,6 +17,11 @@ inputs:
       invocation itself is already handled by the action-no need to prefix the
       command with "taskcat".
     required: true
+  update_taskcat:
+    description: |
+      If set to "true", this action will update taskcat its the latest version
+      before running tests.
+    required: false
 
 runs:
   using: docker

--- a/e2e/resources/action-taskcat.test.ts
+++ b/e2e/resources/action-taskcat.test.ts
@@ -65,4 +65,56 @@ describe("integration tests", () => {
       );
     });
   });
+
+  describe("when update_taskcat is set to true", () => {
+    it("runs the latest version of taskcat", () => {
+      expect.assertions(3);
+
+      const awsAccessKeyId: string | undefined = process.env.AWS_ACCESS_KEY_ID;
+      const awsSecretAccessKey: string | undefined =
+        process.env.AWS_SECRET_ACCESS_KEY;
+
+      expect(awsAccessKeyId).not.toBeUndefined();
+      expect(awsSecretAccessKey).not.toBeUndefined();
+
+      const actOutput: string = cp
+        .execSync(
+          `act \
+        --job taskcat \
+        --directory ./e2e/resources/taskcat_upgrade/true/ \
+        --secret AWS_ACCESS_KEY_ID=${awsAccessKeyId} \
+        --secret AWS_SECRET_ACCESS_KEY=${awsSecretAccessKey}`
+        )
+        .toString();
+
+      expect(actOutput).not.toContain(
+        "A newer version of taskcat is available"
+      );
+    });
+  });
+
+  describe("when update_taskcat is set to false", () => {
+    it("runs an older version of taskcat", () => {
+      expect.assertions(3);
+
+      const awsAccessKeyId: string | undefined = process.env.AWS_ACCESS_KEY_ID;
+      const awsSecretAccessKey: string | undefined =
+        process.env.AWS_SECRET_ACCESS_KEY;
+
+      expect(awsAccessKeyId).not.toBeUndefined();
+      expect(awsSecretAccessKey).not.toBeUndefined();
+
+      const actOutput: string = cp
+        .execSync(
+          `act \
+        --job taskcat \
+        --directory ./e2e/resources/taskcat_upgrade/false/ \
+        --secret AWS_ACCESS_KEY_ID=${awsAccessKeyId} \
+        --secret AWS_SECRET_ACCESS_KEY=${awsSecretAccessKey}`
+        )
+        .toString();
+
+      expect(actOutput).toContain("A newer version of taskcat is available");
+    });
+  });
 });

--- a/e2e/resources/taskcat_upgrade/false/.github/workflows/main.yaml
+++ b/e2e/resources/taskcat_upgrade/false/.github/workflows/main.yaml
@@ -1,0 +1,26 @@
+---
+on: [push]
+
+jobs:
+  taskcat:
+    runs-on: ubuntu-latest
+    name: taskcat
+    # Cannot use GitHub Action's "services" feature due to an issue in act. See nektos/act#173 for more details.
+    # services:
+    #   moto:
+    #     image: motoserver/moto
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: set PY
+        run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
+      - name: taskcat
+        uses: ./../../../../
+        with:
+          commands: test run
+          update_taskcat: false
+        env:
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+          AWS_SESSION_TOKEN: ${{secrets.AWS_SESSION_TOKEN}}

--- a/e2e/resources/taskcat_upgrade/false/.taskcat.yml
+++ b/e2e/resources/taskcat_upgrade/false/.taskcat.yml
@@ -1,0 +1,10 @@
+---
+project:
+  name: action-taskcat-default
+  owner: shahrad@rezaei.io
+
+tests:
+  default:
+    template: templates/dummyStack.yaml
+    regions:
+      - ca-central-1

--- a/e2e/resources/taskcat_upgrade/false/templates/dummyStack.yaml
+++ b/e2e/resources/taskcat_upgrade/false/templates/dummyStack.yaml
@@ -1,0 +1,16 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: |
+  Dummy CloudFormation template used with taskcat test scenarios. This
+  template attempts to create a dummy resource, but the condition is always
+  false - as such, this template never creates anything.
+
+Conditions:
+  AlwaysFalse:
+    Fn::Equals: [true, false]
+
+Resources:
+  DummyResource:
+    Type: Custom::DummyResource
+    Condition: AlwaysFalse

--- a/e2e/resources/taskcat_upgrade/true/.github/workflows/main.yaml
+++ b/e2e/resources/taskcat_upgrade/true/.github/workflows/main.yaml
@@ -1,0 +1,26 @@
+---
+on: [push]
+
+jobs:
+  taskcat:
+    runs-on: ubuntu-latest
+    name: taskcat
+    # Cannot use GitHub Action's "services" feature due to an issue in act. See nektos/act#173 for more details.
+    # services:
+    #   moto:
+    #     image: motoserver/moto
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: set PY
+        run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
+      - name: taskcat
+        uses: ./../../../../
+        with:
+          commands: test run
+          update_taskcat: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+          AWS_SESSION_TOKEN: ${{secrets.AWS_SESSION_TOKEN}}

--- a/e2e/resources/taskcat_upgrade/true/.taskcat.yml
+++ b/e2e/resources/taskcat_upgrade/true/.taskcat.yml
@@ -1,0 +1,10 @@
+---
+project:
+  name: action-taskcat-default
+  owner: shahrad@rezaei.io
+
+tests:
+  default:
+    template: templates/dummyStack.yaml
+    regions:
+      - ca-central-1

--- a/e2e/resources/taskcat_upgrade/true/templates/dummyStack.yaml
+++ b/e2e/resources/taskcat_upgrade/true/templates/dummyStack.yaml
@@ -1,0 +1,16 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: |
+  Dummy CloudFormation template used with taskcat test scenarios. This
+  template attempts to create a dummy resource, but the condition is always
+  false - as such, this template never creates anything.
+
+Conditions:
+  AlwaysFalse:
+    Fn::Equals: [true, false]
+
+Resources:
+  DummyResource:
+    Type: Custom::DummyResource
+    Condition: AlwaysFalse

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,7 @@
 #! /bin/sh
 
-taskcat $@
+if [ "${INPUT_UPDATE_TASKCAT}" == "true" ]; then
+    pip install --upgrade taskcat
+fi
+
+taskcat $@ --minimal-output


### PR DESCRIPTION
Add the update_taskcat input parameter to the GitHub Action based on feedback received in ShahradR/action-taskcat#82. When set to true, the script runs `pip install --upgrade taskcat`, upgrading taskcat to the latest version before running tests.

The `--minimal-output` flag was also added to the script to help with logging issues. See ShahradR/action-taskcat@9111ae4 for more details.

Note that the parameter name uses an underscore instead of a hyphen to separate "update" and "taskcat". This is because the input is read as an environment variable, and only ASCII characters + underscores are allowed.

Associated issue: ShahradR/action-taskcat#82