### PR TITLE
ci: update "Create Release" job result check

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -103,7 +103,7 @@ jobs:
     name: Create release
     runs-on: ubuntu-latest
     needs: [pre-commit, tests, integration-default, integration-update, vale]
-    if: ${{ needs.pre-commit.result == 'success' && needs.tests.result == 'success' && needs.integration.result == 'success' && needs.vale.result == 'success' }}
+    if: ${{ needs.pre-commit.result == 'success' && needs.tests.result == 'success' && needs.integration-default.result == 'success' && needs.integration-update.result == 'success' && needs.vale.result == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
Update "Create Release" job's `if` condition to reflect the new integration test names, and ensure that both the default and update tests pass.