### PR TITLE
feat: add action input param to upgrade cfn-lint

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -104,7 +104,7 @@ jobs:
         with:
           commands: test run --project-root ./e2e/resources/default
           update_taskcat: true
-          update_lint: true
+          update_cfn_lint: true
 
   vale:
     name: Run Vale

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -87,6 +87,25 @@ jobs:
           commands: test run --project-root ./e2e/resources/default
           update_taskcat: true
 
+  integration-lint-update:
+    name: Integration tests - update taskcat
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+      - name: Invoke "taskcat test run"
+        uses: ./
+        with:
+          commands: test run --project-root ./e2e/resources/default
+          update_taskcat: true
+          update_lint: true
+
   vale:
     name: Run Vale
     runs-on: ubuntu-latest
@@ -102,8 +121,16 @@ jobs:
   release:
     name: Create release
     runs-on: ubuntu-latest
-    needs: [pre-commit, tests, integration-default, integration-update, vale]
-    if: ${{ needs.pre-commit.result == 'success' && needs.tests.result == 'success' && needs.integration-default.result == 'success' && needs.integration-update.result == 'success' && needs.vale.result == 'success' }}
+    needs:
+      [
+        pre-commit,
+        tests,
+        integration-default,
+        integration-update,
+        integration-lint-update,
+        vale,
+      ]
+    if: ${{ needs.pre-commit.result == 'success' && needs.tests.result == 'success' && needs.integration-default.result == 'success' && needs.integration-update.result == 'success' && needs.integration-lint-update.result == 'success' && needs.vale.result == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,11 @@ inputs:
       If set to "true", this action will update taskcat its the latest version
       before running tests.
     required: false
+  update_lint:
+    description: |
+      If set to "true", this action will update cfn-lit to its latest version
+      before running tests.
+    required: false
 
 runs:
   using: docker

--- a/action.yaml
+++ b/action.yaml
@@ -22,7 +22,7 @@ inputs:
       If set to "true", this action will update taskcat its the latest version
       before running tests.
     required: false
-  update_lint:
+  update_cfn_lint:
     description: |
       If set to "true", this action will update cfn-lit to its latest version
       before running tests.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,8 @@ if [ "${INPUT_UPDATE_TASKCAT}" == "true" ]; then
     pip install --upgrade taskcat
 fi
 
+if [ "${INPUT_UPDATE_LINT}" == "true" ]; then
+    pip install --upgrade cfn-lint
+fi
+
 taskcat $@ --minimal-output

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ if [ "${INPUT_UPDATE_TASKCAT}" == "true" ]; then
     pip install --upgrade taskcat
 fi
 
-if [ "${INPUT_UPDATE_LINT}" == "true" ]; then
+if [ "${INPUT_UPDATE_CFN_LINT}" == "true" ]; then
     pip install --upgrade cfn-lint
 fi
 


### PR DESCRIPTION
feat: add action input param to upgrade cfn-lint

Add the `update_cfn_lint` input parameter to the GitHub Action based on feedback received in ShahradR/action-taskcat#82. When set to true, the script runs `pip install --upgrade cfn-lint`, upgrading cfn-lint before running tests.

Associated issue: ShahradR/action-taskcat#82