### PR TITLE
fix: update the Node.js and npm versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # hadolint disable=DL3007
 FROM taskcat/taskcat:latest
 
-RUN apk add --no-cache nodejs=12.20.1-r0 npm=12.20.1-r0 && rm -rf /var/cache/apk/*
+RUN apk add --no-cache nodejs=12.21.0-r0 npm=12.21.0-r0 && rm -rf /var/cache/apk/*
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Update the Dockerfile definition and bump the Node.js and npm versions from 12.20.1-r0 to 12.21.0-r0, resolving the "unsatisfiable constraints" error thrown when building the container, as identified by @arniesaha in ShahradR/action-taskcat#82.

This is a recurrence of the issue identified in January and tracked in ShahradR/action-taskcat#74.

Associated issue: ShahradR/action-taskcat#74, ShahradR/action-taskcat#82