### PR TITLE
fix: remove the --minimal-output flag

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,4 +8,4 @@ if [ "${INPUT_UPDATE_CFN_LINT}" == "true" ]; then
     pip install --upgrade cfn-lint
 fi
 
-taskcat $@ --minimal-output
+taskcat $@


### PR DESCRIPTION
Based on feedback received in ShahradR/action-taskcat#90, this commit removes the `--minimal-output` flag, which is only valid for the `test run` command.

This will re-introduce reprint output when running tests, which is not necessarily ordered when printed through GitHub Actions. This will need to be revisited in future commits.

Associated issue: ShahradR/action-taskcat#90