### PR TITLE
fix: pin major version of Node.js, npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # hadolint disable=DL3007
 FROM taskcat/taskcat:latest
 
-RUN apk add --no-cache nodejs=12.21.0-r0 npm=12.21.0-r0 && rm -rf /var/cache/apk/*
+RUN apk add --no-cache nodejs~=12 npm~=12 && rm -rf /var/cache/apk/*
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Because Alpine repositories periodically drop older package versions when new releases are made available, it is difficult to pin specific patch or minor versions.

The taskcat/taskcat:latest container has been configured to use the Alpine 3.12 repositories, which publish version 12 of Node.js and npm. By matching against the major version only, we can protect against future changes to the Alpine repositories.

Associated issue: ShahradR/action-taskcat#74