### PR TITLE
ci: freeze act version to v0.2.20

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install nektos/act
-        run: curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
+        run: curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash -s -- v0.2.20
       - uses: actions/setup-node@v2.1.4
         with:
           node-version: 14


### PR DESCRIPTION
Freeze the [nektos/act](https://github.com/nektos/act) version being downloaded by the CI workflow to [`v0.2.20`](https://github.com/nektos/act/releases/tag/v0.2.20). Tests running against the latest [`v0.2.21`](https://github.com/nektos/act/releases/tag/v0.2.21) release fail when problem matchers are added by the `setup-python` action.

Associated issue: ShahradR/action-taskcat#119