### PR TITLE
test: add e2e default test for @v1 release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -106,18 +106,6 @@ jobs:
           update_taskcat: true
           update_cfn_lint: true
 
-  vale:
-    name: Run Vale
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: errata-ai/vale-action@v1.3.0
-        with:
-          debug: true
-          files: '[ "README.md", "vale/README.md", "src/", "e2e/", "docs/", "__tests__/" ]'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   e2e-v1-default:
     name: End-to-end tests - @v1 - default
     runs-on: ubuntu-latest
@@ -134,6 +122,18 @@ jobs:
         uses: ShahradR/action-taskcat@v1
         with:
           commands: test run --project-root ./e2e/resources/default
+
+  vale:
+    name: Run Vale
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: errata-ai/vale-action@v1.3.0
+        with:
+          debug: true
+          files: '[ "README.md", "vale/README.md", "src/", "e2e/", "docs/", "__tests__/" ]'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: Create release

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,8 +52,8 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  integration-default:
-    name: Integration tests - default
+  e2e-default:
+    name: End-to-end tests - default
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -69,8 +69,8 @@ jobs:
         with:
           commands: test run --project-root ./e2e/resources/default
 
-  integration-update:
-    name: Integration tests - update taskcat
+  e2e-update:
+    name: End-to-end tests - update taskcat
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -87,8 +87,8 @@ jobs:
           commands: test run --project-root ./e2e/resources/default
           update_taskcat: true
 
-  integration-lint-update:
-    name: Integration tests - update taskcat
+  e2e-lint-update:
+    name: End-to-end tests - update taskcat
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -121,16 +121,8 @@ jobs:
   release:
     name: Create release
     runs-on: ubuntu-latest
-    needs:
-      [
-        pre-commit,
-        tests,
-        integration-default,
-        integration-update,
-        integration-lint-update,
-        vale,
-      ]
-    if: ${{ needs.pre-commit.result == 'success' && needs.tests.result == 'success' && needs.integration-default.result == 'success' && needs.integration-update.result == 'success' && needs.integration-lint-update.result == 'success' && needs.vale.result == 'success' }}
+    needs: [pre-commit, tests, e2e-default, e2e-update, e2e-lint-update, vale]
+    if: ${{ needs.pre-commit.result == 'success' && needs.tests.result == 'success' && needs.e2e-default.result == 'success' && needs.e2e-update.result == 'success' && needs.e2e-lint-update.result == 'success' && needs.vale.result == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -118,11 +118,37 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  e2e-v1-default:
+    name: End-to-end tests - @v1 - default
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+      - name: Invoke "taskcat test run"
+        uses: ShahradR/action-taskcat@v1
+        with:
+          commands: test run --project-root ./e2e/resources/default
+
   release:
     name: Create release
     runs-on: ubuntu-latest
-    needs: [pre-commit, tests, e2e-default, e2e-update, e2e-lint-update, vale]
-    if: ${{ needs.pre-commit.result == 'success' && needs.tests.result == 'success' && needs.e2e-default.result == 'success' && needs.e2e-update.result == 'success' && needs.e2e-lint-update.result == 'success' && needs.vale.result == 'success' }}
+    needs:
+      [
+        pre-commit,
+        tests,
+        e2e-default,
+        e2e-update,
+        e2e-lint-update,
+        e2e-v1-default,
+        vale,
+      ]
+    if: ${{ needs.pre-commit.result == 'success' && needs.tests.result == 'success' && needs.e2e-default.result == 'success' && needs.e2e-update.result == 'success' && needs.e2e-lint-update.result == 'success' && needs.e2e-v1-default.result == 'success' && needs.vale.result == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
Add an end-to-end test validating the behavior of this GitHub Action when users reference this action using the `@v1` release. This test specifically validates that the user can execute the `test run` command without any errors.

This pull request also rename the "Integration tests" jobs to "End-to-end tests", since they run from the GitHub runner and connect to a live AWS environment, without any abstraction. This makes them closer to end-to-end tests rather than integration tests, which generally tests the connections between some (but not all) components.

Associated issue: #118