### PR TITLE
feat: update major version branch on new release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -157,4 +157,12 @@ jobs:
         with:
           node-version: 12
       - name: Release
-        run: npx semantic-release
+        uses: cycjimmy/semantic-release-action@v2
+        id: semantic
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update v1 branch reference
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: "git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:refs/heads/v${{steps.semantic.outputs.new_release_major_version}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update the CI workflow to leverage the [`cycjimmy/semantic-release-action`](https://git.io/JYF5k) GitHub Action and update the v1 branch when a new release is published.

This is based on the sample workflow published at https://git.io/JYFdv

Associated issue: ShahradR/action-taskcat#118