### PR TITLE
fix: remove the --minimal-output flag

### DIFF
--- a/src/post-entrypoint.ts
+++ b/src/post-entrypoint.ts
@@ -34,7 +34,6 @@ export class PostEntrypointImpl implements PostEntrypoint {
     this._core.info("Received commands: " + taskcatCommands);
 
     const newList = taskcatCommands.split(" ");
-    newList.push("--minimal-output");
 
     const child = this._cp.spawn("taskcat", newList, {
       stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
Following ShahradR/action-taskcat#90, this commit removes the `--minimal-output` flag that was automatically added to the user-specified commands and passed to taskcat. While this flag works when running `test run`, other commands like `lint` do not recognize the option, causing errors.

This flag was removed from the Bash version of this action in commit 6af43d0. This commit removes it from the TypeScript code, and adds unit tests to ensure that `--minimal-output` is not added to the array of commands sent to taskcat.

Associated issues: ShahradR/action-taskcat#90