### PR TITLE
ci: prefix GitHub Action pull requests with ci

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: daily
     commit-message:
-      prefix: fix
+      prefix: ci
       include: scope
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
Configure Dependabot to create GitHub Action pull requests with the "ci" prefix instead of "fix", preventing semantic-release from creating new versions of the application when merging updates to the CI/CD pipeline.

Closes ShahradR/action-taskcat#139