### PR TITLE
fix: set default for update input parameters

### DIFF
--- a/__tests__/int/post-entrypoint.test.ts
+++ b/__tests__/int/post-entrypoint.test.ts
@@ -1,0 +1,780 @@
+import "reflect-metadata";
+import { Artifact, ChildProcess } from "../../src/interfaces";
+import * as core from "@actions/core";
+import * as cp from "child_process";
+import {
+  mock,
+  mockDeep,
+  anyArray,
+  anyObject,
+  anyFunction,
+} from "jest-mock-extended";
+import { PostEntrypointImpl } from "../../src/post-entrypoint";
+import { TaskcatArtifactManagerImpl } from "../../src/taskcat-artifact-manager";
+import { ChildProcessMock } from "../mocks/childProcessMock";
+import { Readable } from "stream";
+import { InputOptions } from "@actions/core";
+
+jest.mock("@actions/core", () => ({
+  ...jest.requireActual("@actions/core"),
+  info: jest.fn(),
+}));
+
+describe("the PostEntrypoint class", () => {
+  describe("the cfn_lint update function", () => {
+    it("should update cfn_lint if the update_cfn_lint input parameter returns true", async () => {
+      expect.assertions(5);
+
+      // Create real Readable streams (versus the mocks created in other tests).
+      // We can simulate output from taskcat by pushing data to these streams.
+      const pipTaskcatStdout = new Readable();
+      const pipTaskcatStderr = new Readable();
+
+      const pipTaskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipTaskcatStdout,
+        pipTaskcatStderr
+      );
+
+      const pipCfnLintStdout = new Readable();
+      const pipCfnLintStderr = new Readable();
+
+      const pipCfnLintCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipCfnLintStdout,
+        pipCfnLintStderr
+      );
+
+      const taskcatStdout = new Readable();
+      const taskcatStderr = new Readable();
+
+      const taskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        taskcatStdout,
+        taskcatStderr
+      );
+
+      const childProcessMock = mock<ChildProcess>();
+      childProcessMock.spawn.mockImplementation(
+        (
+          command: string,
+          args: readonly string[],
+          options: cp.SpawnOptions
+        ): cp.ChildProcess => {
+          if (command === "pip") {
+            if (args.includes("taskcat")) return pipTaskcatCp;
+            else if (args.includes("cfn_lint")) return pipCfnLintCp;
+            else throw Error("pip was invoked for neither taskcat or cfn_lint");
+          } else if (command === "taskcat") return taskcatCp;
+          else throw Error("This branch should not be reached");
+        }
+      );
+
+      process.env.INPUT_COMMANDS = "test run";
+      process.env.INPUT_UPDATE_CFN_LINT = "true";
+      process.env.INPUT_UPDATE_TASKCAT = "false";
+
+      new PostEntrypointImpl(
+        mock<Artifact>(),
+        core,
+        childProcessMock,
+        mock<TaskcatArtifactManagerImpl>()
+      ).run();
+
+      // Push data to the different streams. Note that we have to end the
+      // stream with `null`, to let it know we're done pushing data.
+      pipCfnLintStdout.push("Output from the pip cfn_lint update stdout");
+      pipCfnLintStdout.push(null);
+
+      pipCfnLintStderr.push("Output from the pip cfn_lint update stderr");
+      pipCfnLintStderr.push(null);
+
+      pipTaskcatStdout.push("Output from the pip taskcat update stdout");
+      pipTaskcatStdout.push(null);
+
+      pipTaskcatStderr.push("Output from the pip taskcat update stderr");
+      pipTaskcatStderr.push(null);
+
+      // Push data to the different streams. Note that we have to end the
+      // stream with `null`, to let it know we're done pushing data.
+      taskcatStdout.push("Output from taskcat's stdout");
+      taskcatStdout.push(null);
+
+      taskcatStderr.push("Output from taskcat's stderr");
+      taskcatStderr.push(null);
+
+      // Delay for 10 milliseconds, to give time for the code to receive and
+      // process the stdout and stderr data we just pushed.
+      await sleep(10);
+      expect(core.info).toHaveBeenNthCalledWith(
+        1,
+        "Received commands: test run"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        2,
+        "Output from the pip cfn_lint update stdout"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        3,
+        "Output from the pip cfn_lint update stderr"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        4,
+        "Output from taskcat's stdout"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        5,
+        "Output from taskcat's stderr"
+      );
+
+      function sleep(ms: number) {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+      }
+    });
+
+    it("should not update cfn_lint if the update_cfn_lint input parameter returns false", async () => {
+      expect.assertions(3);
+
+      // Create real Readable streams (versus the mocks created in other tests).
+      // We can simulate output from taskcat by pushing data to these streams.
+      const pipTaskcatStdout = new Readable();
+      const pipTaskcatStderr = new Readable();
+
+      const pipTaskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipTaskcatStdout,
+        pipTaskcatStderr
+      );
+
+      const pipCfnLintStdout = new Readable();
+      const pipCfnLintStderr = new Readable();
+
+      const pipCfnLintCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipCfnLintStdout,
+        pipCfnLintStderr
+      );
+
+      const taskcatStdout = new Readable();
+      const taskcatStderr = new Readable();
+
+      const taskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        taskcatStdout,
+        taskcatStderr
+      );
+
+      const childProcessMock = mock<ChildProcess>();
+      childProcessMock.spawn.mockImplementation(
+        (
+          command: string,
+          args: readonly string[],
+          options: cp.SpawnOptions
+        ): cp.ChildProcess => {
+          if (command === "pip") {
+            if (args.includes("taskcat")) return pipTaskcatCp;
+            else if (args.includes("cfn_lint")) return pipCfnLintCp;
+            else throw Error("pip was invoked for neither taskcat or cfn_lint");
+          } else if (command === "taskcat") return taskcatCp;
+          else throw Error("This branch should not be reached");
+        }
+      );
+
+      process.env.INPUT_COMMANDS = "test run";
+      process.env.INPUT_UPDATE_CFN_LINT = "false";
+      process.env.INPUT_UPDATE_TASKCAT = "false";
+
+      new PostEntrypointImpl(
+        mock<Artifact>(),
+        core,
+        childProcessMock,
+        mock<TaskcatArtifactManagerImpl>()
+      ).run();
+
+      // Push data to the different streams. Note that we have to end the
+      // stream with `null`, to let it know we're done pushing data.
+      pipCfnLintStdout.push("Output from the pip cfn_lint update stdout");
+      pipCfnLintStdout.push(null);
+
+      pipCfnLintStderr.push("Output from the pip cfn_lint update stderr");
+      pipCfnLintStderr.push(null);
+
+      pipTaskcatStdout.push("Output from the pip taskcat update stdout");
+      pipTaskcatStdout.push(null);
+
+      pipTaskcatStderr.push("Output from the pip taskcat update stderr");
+      pipTaskcatStderr.push(null);
+
+      // Push data to the different streams. Note that we have to end the
+      // stream with `null`, to let it know we're done pushing data.
+      taskcatStdout.push("Output from taskcat's stdout");
+      taskcatStdout.push(null);
+
+      taskcatStderr.push("Output from taskcat's stderr");
+      taskcatStderr.push(null);
+
+      // Delay for 10 milliseconds, to give time for the code to receive and
+      // process the stdout and stderr data we just pushed.
+      await sleep(10);
+      expect(core.info).toHaveBeenNthCalledWith(
+        1,
+        "Received commands: test run"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        2,
+        "Output from taskcat's stdout"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        3,
+        "Output from taskcat's stderr"
+      );
+
+      function sleep(ms: number) {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+      }
+    });
+
+    it("should not update cfn_lint if the update_cfn_lint input parameter is not defined", async () => {
+      expect.assertions(3);
+
+      // Create real Readable streams (versus the mocks created in other tests).
+      // We can simulate output from taskcat by pushing data to these streams.
+      const pipTaskcatStdout = new Readable();
+      const pipTaskcatStderr = new Readable();
+
+      const pipTaskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipTaskcatStdout,
+        pipTaskcatStderr
+      );
+
+      const pipCfnLintStdout = new Readable();
+      const pipCfnLintStderr = new Readable();
+
+      const pipCfnLintCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipCfnLintStdout,
+        pipCfnLintStderr
+      );
+
+      const taskcatStdout = new Readable();
+      const taskcatStderr = new Readable();
+
+      const taskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        taskcatStdout,
+        taskcatStderr
+      );
+
+      const childProcessMock = mock<ChildProcess>();
+      childProcessMock.spawn.mockImplementation(
+        (
+          command: string,
+          args: readonly string[],
+          options: cp.SpawnOptions
+        ): cp.ChildProcess => {
+          if (command === "pip") {
+            if (args.includes("taskcat")) return pipTaskcatCp;
+            else if (args.includes("cfn_lint")) return pipCfnLintCp;
+            else throw Error("pip was invoked for neither taskcat or cfn_lint");
+          } else if (command === "taskcat") return taskcatCp;
+          else throw Error("This branch should not be reached");
+        }
+      );
+
+      process.env.INPUT_COMMANDS = "test run";
+      process.env.INPUT_UPDATE_CFN_LINT = "";
+      process.env.INPUT_UPDATE_TASKCAT = "false";
+
+      new PostEntrypointImpl(
+        mock<Artifact>(),
+        core,
+        childProcessMock,
+        mock<TaskcatArtifactManagerImpl>()
+      ).run();
+
+      // Push data to the different streams. Note that we have to end the
+      // stream with `null`, to let it know we're done pushing data.
+      pipCfnLintStdout.push("Output from the pip cfn_lint update stdout");
+      pipCfnLintStdout.push(null);
+
+      pipCfnLintStderr.push("Output from the pip cfn_lint update stderr");
+      pipCfnLintStderr.push(null);
+
+      pipTaskcatStdout.push("Output from the pip taskcat update stdout");
+      pipTaskcatStdout.push(null);
+
+      pipTaskcatStderr.push("Output from the pip taskcat update stderr");
+      pipTaskcatStderr.push(null);
+
+      // Push data to the different streams. Note that we have to end the
+      // stream with `null`, to let it know we're done pushing data.
+      taskcatStdout.push("Output from taskcat's stdout");
+      taskcatStdout.push(null);
+
+      taskcatStderr.push("Output from taskcat's stderr");
+      taskcatStderr.push(null);
+
+      // Delay for 10 milliseconds, to give time for the code to receive and
+      // process the stdout and stderr data we just pushed.
+      await sleep(10);
+      expect(core.info).toHaveBeenNthCalledWith(
+        1,
+        "Received commands: test run"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        2,
+        "Output from taskcat's stdout"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        3,
+        "Output from taskcat's stderr"
+      );
+
+      function sleep(ms: number) {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+      }
+    });
+
+    it("should update taskcat if the update_taskcat input parameter returns true", async () => {
+      expect.assertions(5);
+
+      // Create real Readable streams (versus the mocks created in other tests).
+      // We can simulate output from taskcat by pushing data to these streams.
+      const pipTaskcatStdout = new Readable();
+      const pipTaskcatStderr = new Readable();
+
+      const pipTaskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipTaskcatStdout,
+        pipTaskcatStderr
+      );
+
+      const pipCfnLintStdout = new Readable();
+      const pipCfnLintStderr = new Readable();
+
+      const pipCfnLintCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipCfnLintStdout,
+        pipCfnLintStderr
+      );
+
+      const taskcatStdout = new Readable();
+      const taskcatStderr = new Readable();
+
+      const taskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        taskcatStdout,
+        taskcatStderr
+      );
+
+      const childProcessMock = mock<ChildProcess>();
+      childProcessMock.spawn.mockImplementation(
+        (
+          command: string,
+          args: readonly string[],
+          options: cp.SpawnOptions
+        ): cp.ChildProcess => {
+          if (command === "pip") {
+            if (args.includes("taskcat")) return pipTaskcatCp;
+            else if (args.includes("cfn_lint")) return pipCfnLintCp;
+            else throw Error("pip was invoked for neither taskcat or cfn_lint");
+          } else if (command === "taskcat") return taskcatCp;
+          else throw Error("This branch should not be reached");
+        }
+      );
+
+      process.env.INPUT_COMMANDS = "test run";
+      process.env.INPUT_UPDATE_CFN_LINT = "false";
+      process.env.INPUT_UPDATE_TASKCAT = "true";
+
+      new PostEntrypointImpl(
+        mock<Artifact>(),
+        core,
+        childProcessMock,
+        mock<TaskcatArtifactManagerImpl>()
+      ).run();
+
+      // Push data to the different streams. Note that we have to end the
+      // stream with `null`, to let it know we're done pushing data.
+      pipCfnLintStdout.push("Output from the pip cfn_lint update stdout");
+      pipCfnLintStdout.push(null);
+
+      pipCfnLintStderr.push("Output from the pip cfn_lint update stderr");
+      pipCfnLintStderr.push(null);
+
+      pipTaskcatStdout.push("Output from the pip taskcat update stdout");
+      pipTaskcatStdout.push(null);
+
+      pipTaskcatStderr.push("Output from the pip taskcat update stderr");
+      pipTaskcatStderr.push(null);
+
+      // Push data to the different streams. Note that we have to end the
+      // stream with `null`, to let it know we're done pushing data.
+      taskcatStdout.push("Output from taskcat's stdout");
+      taskcatStdout.push(null);
+
+      taskcatStderr.push("Output from taskcat's stderr");
+      taskcatStderr.push(null);
+
+      // Delay for 10 milliseconds, to give time for the code to receive and
+      // process the stdout and stderr data we just pushed.
+      await sleep(10);
+      expect(core.info).toHaveBeenNthCalledWith(
+        1,
+        "Received commands: test run"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        2,
+        "Output from the pip taskcat update stdout"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        3,
+        "Output from the pip taskcat update stderr"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        4,
+        "Output from taskcat's stdout"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        5,
+        "Output from taskcat's stderr"
+      );
+
+      function sleep(ms: number) {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+      }
+    });
+    it("should not update taskcat if the update_taskcat input parameter returns false", async () => {
+      expect.assertions(3);
+
+      // Create real Readable streams (versus the mocks created in other tests).
+      // We can simulate output from taskcat by pushing data to these streams.
+      const pipTaskcatStdout = new Readable();
+      const pipTaskcatStderr = new Readable();
+
+      const pipTaskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipTaskcatStdout,
+        pipTaskcatStderr
+      );
+
+      const pipCfnLintStdout = new Readable();
+      const pipCfnLintStderr = new Readable();
+
+      const pipCfnLintCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipCfnLintStdout,
+        pipCfnLintStderr
+      );
+
+      const taskcatStdout = new Readable();
+      const taskcatStderr = new Readable();
+
+      const taskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        taskcatStdout,
+        taskcatStderr
+      );
+
+      const childProcessMock = mock<ChildProcess>();
+      childProcessMock.spawn.mockImplementation(
+        (
+          command: string,
+          args: readonly string[],
+          options: cp.SpawnOptions
+        ): cp.ChildProcess => {
+          if (command === "pip") {
+            if (args.includes("taskcat")) return pipTaskcatCp;
+            else if (args.includes("cfn_lint")) return pipCfnLintCp;
+            else throw Error("pip was invoked for neither taskcat or cfn_lint");
+          } else if (command === "taskcat") return taskcatCp;
+          else throw Error("This branch should not be reached");
+        }
+      );
+
+      process.env.INPUT_COMMANDS = "test run";
+      process.env.INPUT_UPDATE_CFN_LINT = "false";
+      process.env.INPUT_UPDATE_TASKCAT = "false";
+
+      new PostEntrypointImpl(
+        mock<Artifact>(),
+        core,
+        childProcessMock,
+        mock<TaskcatArtifactManagerImpl>()
+      ).run();
+
+      // Push data to the different streams. Note that we have to end the
+      // stream with `null`, to let it know we're done pushing data.
+      pipCfnLintStdout.push("Output from the pip cfn_lint update stdout");
+      pipCfnLintStdout.push(null);
+
+      pipCfnLintStderr.push("Output from the pip cfn_lint update stderr");
+      pipCfnLintStderr.push(null);
+
+      pipTaskcatStdout.push("Output from the pip taskcat update stdout");
+      pipTaskcatStdout.push(null);
+
+      pipTaskcatStderr.push("Output from the pip taskcat update stderr");
+      pipTaskcatStderr.push(null);
+
+      // Push data to the different streams. Note that we have to end the
+      // stream with `null`, to let it know we're done pushing data.
+      taskcatStdout.push("Output from taskcat's stdout");
+      taskcatStdout.push(null);
+
+      taskcatStderr.push("Output from taskcat's stderr");
+      taskcatStderr.push(null);
+
+      // Delay for 10 milliseconds, to give time for the code to receive and
+      // process the stdout and stderr data we just pushed.
+      await sleep(10);
+      expect(core.info).toHaveBeenNthCalledWith(
+        1,
+        "Received commands: test run"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        2,
+        "Output from taskcat's stdout"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        3,
+        "Output from taskcat's stderr"
+      );
+
+      function sleep(ms: number) {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+      }
+    });
+
+    it("should not update taskcat if the update_taskcat input parameter is not defined", async () => {
+      expect.assertions(3);
+
+      // Create real Readable streams (versus the mocks created in other tests).
+      // We can simulate output from taskcat by pushing data to these streams.
+      const pipTaskcatStdout = new Readable();
+      const pipTaskcatStderr = new Readable();
+
+      const pipTaskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipTaskcatStdout,
+        pipTaskcatStderr
+      );
+
+      const pipCfnLintStdout = new Readable();
+      const pipCfnLintStderr = new Readable();
+
+      const pipCfnLintCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipCfnLintStdout,
+        pipCfnLintStderr
+      );
+
+      const taskcatStdout = new Readable();
+      const taskcatStderr = new Readable();
+
+      const taskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        taskcatStdout,
+        taskcatStderr
+      );
+
+      const childProcessMock = mock<ChildProcess>();
+      childProcessMock.spawn.mockImplementation(
+        (
+          command: string,
+          args: readonly string[],
+          options: cp.SpawnOptions
+        ): cp.ChildProcess => {
+          if (command === "pip") {
+            if (args.includes("taskcat")) return pipTaskcatCp;
+            else if (args.includes("cfn_lint")) return pipCfnLintCp;
+            else throw Error("pip was invoked for neither taskcat or cfn_lint");
+          } else if (command === "taskcat") return taskcatCp;
+          else throw Error("This branch should not be reached");
+        }
+      );
+
+      process.env.INPUT_COMMANDS = "test run";
+      process.env.INPUT_UPDATE_TASKCAT = "";
+      process.env.INPUT_UPDATE_CFN_LINT = "false";
+
+      new PostEntrypointImpl(
+        mock<Artifact>(),
+        core,
+        childProcessMock,
+        mock<TaskcatArtifactManagerImpl>()
+      ).run();
+
+      // Push data to the different streams. Note that we have to end the
+      // stream with `null`, to let it know we're done pushing data.
+      pipCfnLintStdout.push("Output from the pip cfn_lint update stdout");
+      pipCfnLintStdout.push(null);
+
+      pipCfnLintStderr.push("Output from the pip cfn_lint update stderr");
+      pipCfnLintStderr.push(null);
+
+      pipTaskcatStdout.push("Output from the pip taskcat update stdout");
+      pipTaskcatStdout.push(null);
+
+      pipTaskcatStderr.push("Output from the pip taskcat update stderr");
+      pipTaskcatStderr.push(null);
+
+      // Push data to the different streams. Note that we have to end the
+      // stream with `null`, to let it know we're done pushing data.
+      taskcatStdout.push("Output from taskcat's stdout");
+      taskcatStdout.push(null);
+
+      taskcatStderr.push("Output from taskcat's stderr");
+      taskcatStderr.push(null);
+
+      // Delay for 10 milliseconds, to give time for the code to receive and
+      // process the stdout and stderr data we just pushed.
+      await sleep(10);
+      expect(core.info).toHaveBeenNthCalledWith(
+        1,
+        "Received commands: test run"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        2,
+        "Output from taskcat's stdout"
+      );
+      expect(core.info).toHaveBeenNthCalledWith(
+        3,
+        "Output from taskcat's stderr"
+      );
+
+      function sleep(ms: number) {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+      }
+    });
+
+    it("should throw an exception if the update_cfn_lint input parameter is not a boolean", async () => {
+      expect.assertions(1);
+
+      // Create real Readable streams (versus the mocks created in other tests).
+      // We can simulate output from taskcat by pushing data to these streams.
+      const pipTaskcatStdout = new Readable();
+      const pipTaskcatStderr = new Readable();
+
+      const pipTaskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipTaskcatStdout,
+        pipTaskcatStderr
+      );
+
+      const pipCfnLintStdout = new Readable();
+      const pipCfnLintStderr = new Readable();
+
+      const pipCfnLintCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipCfnLintStdout,
+        pipCfnLintStderr
+      );
+
+      const taskcatStdout = new Readable();
+      const taskcatStderr = new Readable();
+
+      const taskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        taskcatStdout,
+        taskcatStderr
+      );
+
+      const childProcessMock = mock<ChildProcess>();
+      childProcessMock.spawn.mockImplementation(
+        (
+          command: string,
+          args: readonly string[],
+          options: cp.SpawnOptions
+        ): cp.ChildProcess => {
+          if (command === "pip") {
+            if (args.includes("taskcat")) return pipTaskcatCp;
+            else if (args.includes("cfn_lint")) return pipCfnLintCp;
+            else throw Error("pip was invoked for neither taskcat or cfn_lint");
+          } else if (command === "taskcat") return taskcatCp;
+          else throw Error("This branch should not be reached");
+        }
+      );
+
+      process.env.INPUT_COMMANDS = "test run";
+      process.env.INPUT_UPDATE_TASKCAT = "false";
+      process.env.INPUT_UPDATE_CFN_LINT = "test";
+
+      expect(() => {
+        new PostEntrypointImpl(
+          mock<Artifact>(),
+          core,
+          childProcessMock,
+          mock<TaskcatArtifactManagerImpl>()
+        ).run();
+      }).toThrow(
+        'Input does not meet YAML 1.2 "Core Schema" specification: update_cfn_lint\nSupport boolean input list: `true | True | TRUE | false | False | FALSE`'
+      );
+    });
+
+    it("should throw an exception if the update_taskcat input parameter is not a boolean", async () => {
+      expect.assertions(1);
+
+      // Create real Readable streams (versus the mocks created in other tests).
+      // We can simulate output from taskcat by pushing data to these streams.
+      const pipTaskcatStdout = new Readable();
+      const pipTaskcatStderr = new Readable();
+
+      const pipTaskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipTaskcatStdout,
+        pipTaskcatStderr
+      );
+
+      const pipCfnLintStdout = new Readable();
+      const pipCfnLintStderr = new Readable();
+
+      const pipCfnLintCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        pipCfnLintStdout,
+        pipCfnLintStderr
+      );
+
+      const taskcatStdout = new Readable();
+      const taskcatStderr = new Readable();
+
+      const taskcatCp: cp.ChildProcess = new ChildProcessMock(
+        0,
+        taskcatStdout,
+        taskcatStderr
+      );
+
+      const childProcessMock = mock<ChildProcess>();
+      childProcessMock.spawn.mockImplementation(
+        (
+          command: string,
+          args: readonly string[],
+          options: cp.SpawnOptions
+        ): cp.ChildProcess => {
+          if (command === "pip") {
+            if (args.includes("taskcat")) return pipTaskcatCp;
+            else if (args.includes("cfn_lint")) return pipCfnLintCp;
+            else throw Error("pip was invoked for neither taskcat or cfn_lint");
+          } else if (command === "taskcat") return taskcatCp;
+          else throw Error("This branch should not be reached");
+        }
+      );
+
+      process.env.INPUT_COMMANDS = "test run";
+      process.env.INPUT_UPDATE_TASKCAT = "test";
+      process.env.INPUT_UPDATE_CFN_LINT = "false";
+
+      expect(() => {
+        new PostEntrypointImpl(
+          mock<Artifact>(),
+          core,
+          childProcessMock,
+          mock<TaskcatArtifactManagerImpl>()
+        ).run();
+      }).toThrow(
+        'Input does not meet YAML 1.2 "Core Schema" specification: update_taskcat\nSupport boolean input list: `true | True | TRUE | false | False | FALSE`'
+      );
+    });
+  });
+});

--- a/dist/index.js
+++ b/dist/index.js
@@ -13869,8 +13869,28 @@ var PostEntrypointImpl = /** @class */ (function () {
         var _this = this;
         var awsAccountId = this._core.getInput("aws-account-id");
         var taskcatCommands = this._core.getInput("commands");
-        var updateCfnLint = this._core.getBooleanInput("update_cfn_lint");
-        var updateTaskcat = this._core.getBooleanInput("update_taskcat");
+        var updateCfnLint;
+        var updateTaskcat;
+        try {
+            updateCfnLint = this._core.getBooleanInput("update_cfn_lint");
+        }
+        catch (e) {
+            if (e instanceof TypeError &&
+                this._core.getInput("update_cfn_lint") === "")
+                updateCfnLint = false;
+            else
+                throw e;
+        }
+        try {
+            updateTaskcat = this._core.getBooleanInput("update_taskcat");
+        }
+        catch (e) {
+            if (e instanceof TypeError &&
+                this._core.getInput("update_taskcat") === "")
+                updateTaskcat = false;
+            else
+                throw e;
+        }
         this._core.info("Received commands: " + taskcatCommands);
         if (updateCfnLint) {
             var updateCfnLintChild = this._cp.spawn("pip", ["install", "--upgrade", "cfn_lint"], {

--- a/src/post-entrypoint.ts
+++ b/src/post-entrypoint.ts
@@ -31,10 +31,32 @@ export class PostEntrypointImpl implements PostEntrypoint {
   public run(): void {
     const awsAccountId = this._core.getInput("aws-account-id");
     const taskcatCommands = this._core.getInput("commands");
-    const updateCfnLint: boolean = this._core.getBooleanInput(
-      "update_cfn_lint"
-    );
-    const updateTaskcat: boolean = this._core.getBooleanInput("update_taskcat");
+
+    let updateCfnLint: boolean;
+    let updateTaskcat: boolean;
+
+    try {
+      updateCfnLint = this._core.getBooleanInput("update_cfn_lint");
+    } catch (e) {
+      if (
+        e instanceof TypeError &&
+        this._core.getInput("update_cfn_lint") === ""
+      )
+        updateCfnLint = false;
+      else throw e;
+    }
+
+    try {
+      updateTaskcat = this._core.getBooleanInput("update_taskcat");
+    } catch (e) {
+      if (
+        e instanceof TypeError &&
+        this._core.getInput("update_taskcat") === ""
+      )
+        updateTaskcat = false;
+      else throw e;
+    }
+
     this._core.info("Received commands: " + taskcatCommands);
 
     if (updateCfnLint) {


### PR DESCRIPTION
The `core.getBooleanInput()` function reads environment variables to get values for the different input parameters.

However, in Unix-based operating systems, if an undefined environment variable is called, an empty string is returned. Because empty strings aren't allowed when defining a boolean value in the YAML 1.2 spec, the `getBooleanInput()` function throws an exception.

This commit verifies if the `update_taskcat` and `update_cfn_lint` parameters have an empty string value: if so, the parameter's value is set to false, and the exception is suppressed. This gives parity between the Bash and TypeScript versions of the application, and allows users to continue using their CI/CD pipelines with no change.

See https://git.io/JKcmg for details on the `getBooleanInput()` function implementation.