### PR TITLE
fix: remove \r, \n characters from EOL

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13899,10 +13899,10 @@ var PostEntrypointImpl = /** @class */ (function () {
             updateCfnLintChild.stdout.setEncoding("utf-8");
             updateCfnLintChild.stderr.setEncoding("utf-8");
             updateCfnLintChild.stdout.on("data", function (data) {
-                _this._core.info(data);
+                _this._core.info(data.replace(/\r?\n$/g, ""));
             });
             updateCfnLintChild.stderr.on("data", function (data) {
-                _this._core.info(data);
+                _this._core.info(data.replace(/\r?\n$/g, ""));
             });
         }
         if (updateTaskcat) {
@@ -13912,10 +13912,10 @@ var PostEntrypointImpl = /** @class */ (function () {
             updateTaskcatChild.stdout.setEncoding("utf-8");
             updateTaskcatChild.stderr.setEncoding("utf-8");
             updateTaskcatChild.stdout.on("data", function (data) {
-                _this._core.info(data);
+                _this._core.info(data.replace(/\r?\n$/g, ""));
             });
             updateTaskcatChild.stderr.on("data", function (data) {
-                _this._core.info(data);
+                _this._core.info(data.replace(/\r?\n$/g, ""));
             });
         }
         var newList = taskcatCommands.split(" ");
@@ -13925,10 +13925,10 @@ var PostEntrypointImpl = /** @class */ (function () {
         child.stdout.setEncoding("utf-8");
         child.stderr.setEncoding("utf-8");
         child.stdout.on("data", function (data) {
-            _this._core.info(data);
+            _this._core.info(data.replace(/\r?\n$/g, ""));
         });
         child.stderr.on("data", function (data) {
-            _this._core.info(data);
+            _this._core.info(data.replace(/\r?\n$/g, ""));
         });
         child.on("exit", function (exitCode) {
             _this._taskcatArtifactManager.maskAndPublishTaskcatArtifacts(awsAccountId);

--- a/src/post-entrypoint.ts
+++ b/src/post-entrypoint.ts
@@ -72,11 +72,11 @@ export class PostEntrypointImpl implements PostEntrypoint {
       updateCfnLintChild.stderr.setEncoding("utf-8");
 
       updateCfnLintChild.stdout.on("data", (data) => {
-        this._core.info(data);
+        this._core.info(data.replace(/\r?\n$/g, ""));
       });
 
       updateCfnLintChild.stderr.on("data", (data) => {
-        this._core.info(data);
+        this._core.info(data.replace(/\r?\n$/g, ""));
       });
     }
 
@@ -93,11 +93,11 @@ export class PostEntrypointImpl implements PostEntrypoint {
       updateTaskcatChild.stderr.setEncoding("utf-8");
 
       updateTaskcatChild.stdout.on("data", (data) => {
-        this._core.info(data);
+        this._core.info(data.replace(/\r?\n$/g, ""));
       });
 
       updateTaskcatChild.stderr.on("data", (data) => {
-        this._core.info(data);
+        this._core.info(data.replace(/\r?\n$/g, ""));
       });
     }
 
@@ -111,11 +111,11 @@ export class PostEntrypointImpl implements PostEntrypoint {
     child.stderr.setEncoding("utf-8");
 
     child.stdout.on("data", (data) => {
-      this._core.info(data);
+      this._core.info(data.replace(/\r?\n$/g, ""));
     });
 
     child.stderr.on("data", (data) => {
-      this._core.info(data);
+      this._core.info(data.replace(/\r?\n$/g, ""));
     });
 
     child.on("exit", (exitCode) => {


### PR DESCRIPTION
Remove the carriage return (`\r`) and line feed (`\n`) characters from the Python output's end of line.

We leverage the [`@action/core`](https://github.com/actions/toolkit/tree/6ce349e08cc692c789ab21189a31f687dc8a1cf8/packages/core)'s [`info()`](https://github.com/actions/toolkit/blob/6ce349e08cc692c789ab21189a31f687dc8a1cf8/packages/core/src/core.ts#L291) function to print text to the console when running this GitHub Action. However, `info()` automatically adds `\r\n` or `\n` to the end of the string, depending on the OS. Because the Python output also contain newline characters, we end up with an extra blank line every time we print something to the console.

Because the `info()` function doesn't provide a way to override this behavior, we work around it by removing `\r\n` and `\n` characters from the end of our line before printing it. It is important to preserve newline characters in the middle of a string though, since that's sometimes used by applications, like to render the taskcat ASCII text art, displayed when invoking the command.

# Action output without removing newline characters
![output-crlf](https://user-images.githubusercontent.com/5815058/137613756-10ece094-5785-4b8d-a94b-ad89d2a4da3d.png)

# Action output when removing all newline characters
![output-crlf-all](https://user-images.githubusercontent.com/5815058/137613762-681cbe1d-d25a-42bc-addf-7f88685cab4a.png)

# Action output when removing newline characters at the end of the string
![output-crlf-eol](https://user-images.githubusercontent.com/5815058/137613765-9ac6797e-db1b-4fc2-8873-1a41691ac40e.png)
