### PR TITLE
Specify installation directory for act in the CI workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,6 @@
 name: CI workflow
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   pre-commit:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install nektos/act
-        run: curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash -s -- v0.2.20
+        run: curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash -s -- -b /usr/local/bin/ v0.2.20
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: 14


### PR DESCRIPTION
Update the CI workflow to install [act](https://github.com/nektos/act) in the `/usr/local/bin` directory, after the Jest tests started failing with error ` /bin/sh: 1: act: not found`.

This pull request also adds the `workflow_dispatch` trigger to the CI workflow, allowing the workflow to be ran from the GitHub UI, without having to create a commit beforehand. See [_Manually run a workflow_](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) on the GitHub Docs site for more details.