### PR TITLE
ci: wait for CI status when merging Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -10,8 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      - name: "Wait for status checks"
+        id: waitforstatuschecks
+        uses: "WyriHaximus/github-action-wait-for-status@v2"
+        with:
+          ignoreActions: Automerge PRs
+          checkInterval: 300
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Dependabot metadata
         id: metadata
+        if: ${{ steps.waitforstatuschecks.outputs.status == 'success' }}
         uses: dependabot/fetch-metadata@v1.2.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Configure the Dependabot auto-merge workflow to wait for the CI workflow to complete before merging the pull request to the main branch, by leveraging the [WyriHaximus/github-action-wait-for-status](https://github.com/WyriHaximus/github-action-wait-for-status) GitHub Action.