### PR TITLE
ci: grant write permissions to the CI workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,6 +2,9 @@ name: CI workflow
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  checks: write
+
 jobs:
   pre-commit:
     name: Run pre-commit checks


### PR DESCRIPTION
Grant write permissions to actions in the CI workflow by leveraging the `permissions` key, allowing jobs like Vale to run when invoked by Dependabot. See the [_GitHub Actions: Control permissions for GITHUB_TOKEN_](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/) article on the GitHub blog for more details.