### PR TITLE
ci: add permissions for semantic-release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,8 @@ on: [push, pull_request, workflow_dispatch]
 
 permissions:
   checks: write
+  issues: write
+  contents: write
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Add the issues and contents permission for the semantic-release job in the CI workflow.

The job pushes release information to the repository, and in case of failures, will open an issue against the GitHub project.