### PR TITLE
chore: set waitforstatuschecks version to v1.4.0

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: "Wait for status checks"
         id: waitforstatuschecks
-        uses: "WyriHaximus/github-action-wait-for-status@v2"
+        uses: "WyriHaximus/github-action-wait-for-status@v1.4.0"
         with:
           ignoreActions: Automerge PRs
           checkInterval: 300


### PR DESCRIPTION
Set the version for the [WyriHaximus/github-action-wait-for-status](https://github.com/WyriHaximus/github-action-wait-for-status) GitHub Action to v1.4.0, after it was erroneously set to v2.