### PR TITLE
ci: ignore wait job when merging Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   dependabot:
+    name: Automerge PRs
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:


### PR DESCRIPTION
Ignore the "Automerge PRs" GitHub workflow job when waiting for other jobs to complete during Dependabot pull request merges.

Currently, the status check job waits on itself, preventing the job from completing, eventually timing out after six hours.