### PR TITLE
Feature/dockerfile node fix for action-taskcat@v1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8.13-alpine3.15
 
 RUN apk add --no-cache python3-dev~3.9 gcc~10 libc-dev~0.7 nodejs~16 npm~8 && rm -rf /var/cache/apk/*
 
-RUN pip3 install taskcat==0.9.30 --upgrade
+RUN pip3 install taskcat==0.9.23 --upgrade
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-# For v0.9 and higher, the taskcat containers do not pin specific
-# versions. Rather, they always fetch the latest version from pip. See
-# https://dockr.ly/2BjpG7C to see the taskcat Dockerfile.
+FROM python:3.8.13-alpine3.15
 
-# hadolint disable=DL3007
-FROM taskcat/taskcat:latest
+RUN apk add --no-cache python3-dev~3.9 gcc~10 libc-dev~0.7 nodejs~16 npm~8 && rm -rf /var/cache/apk/*
 
-RUN apk add --no-cache nodejs~=12 npm~=12 && rm -rf /var/cache/apk/*
+RUN pip3 install taskcat==0.9.30 --upgrade
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Update the Dockerfile to install taskcat from python:3.8.13-alpine3.15, after the taskcat/taskcat:latest image was rebuilt and now uses Alpine v3.15 and Python 3.10.

In Python 3.3, abstract base classes were moved from the "collections" module to "collections.abc". In Python 3.10, the classes were removed from the "collections" module, which causes certain taskcat commands to return with error "AttributeError module 'collections' has no attribute 'Mapping'". See section [8.4. of the Python documentation](https://bit.ly/3vnAnOr) for more details.

In order to maintain compatibility with existing GitHub workflows, pin the taskcat version to v0.9.23. Users can upgrade both taskcat and cfn_lint to their latest versions by setting the `upgrade_taskcat` and `upgrade_cfn_lint` input parameter in their workflows, respectively.

Certain tests in the CI pipeline are failing—the end-to-end tests verifying the tagged action version will be resolved once this code is merged, and the Jest tests will be reviewed in a future commit, and shouldn't affect functionality, since they target the TypeScript version of the action, which is not yet live.

Associated issue: https://github.com/ShahradR/action-taskcat/issues/298