### PR TITLE
ci: only auto-merge when CI build passes

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -19,13 +19,8 @@ jobs:
           checkInterval: 300
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Dependabot metadata
-        id: metadata
-        if: ${{ steps.waitforstatuschecks.outputs.status == 'success' }}
-        uses: dependabot/fetch-metadata@v1.3.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
+        if: ${{ steps.waitforstatuschecks.outputs.status == 'success' }}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
Update the "Dependabot auto-merge" GitHub workflow to only merge pull requests if the build passes.

After the check for major/minor version was removed in commit cbf8dfb, the workflow automatically merges pull requests, regardless of whether the other workflows have passed or failed.

This commit removes the fetch-metadata step, and adds the github-action-wait-for-status status condition to the auto-merge step.