### PR TITLE
ci: split end-to-end tests in a separate workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,175 @@
+name: CI workflow
+
+on:
+  - workflow_dispatch
+  - schedule:
+      - cron: "0 18 * * *"
+
+permissions:
+  checks: write
+  issues: write
+  contents: write
+
+jobs:
+  e2e-default:
+    name: End-to-end tests - default
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        id: aws-credentials
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+      - name: Invoke "taskcat test run"
+        uses: ./
+        with:
+          commands: test run --lint-disable --project-root ./e2e/resources/default
+
+  e2e-update:
+    name: End-to-end tests - update taskcat
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+      - name: Invoke "taskcat test run"
+        uses: ./
+        with:
+          commands: test run --lint-disable --project-root ./e2e/resources/default
+          update_taskcat: true
+
+  e2e-lint-update:
+    name: End-to-end tests - update taskcat
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+      - name: Invoke "taskcat test run"
+        uses: ./
+        with:
+          commands: test run --lint-disable --project-root ./e2e/resources/default
+          update_taskcat: true
+          update_cfn_lint: true
+
+  e2e-v1-default:
+    name: End-to-end tests - @v1 - default
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+      - name: Invoke "taskcat test run"
+        uses: ShahradR/action-taskcat@v1
+        with:
+          commands: test run --lint-disable --project-root ./e2e/resources/default
+
+  e2e-v1-update:
+    name: End-to-end tests - @v1 - update taskcat
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+      - name: Invoke "taskcat test run --lint-disable"
+        uses: ShahradR/action-taskcat@v1
+        with:
+          commands: test run --project-root ./e2e/resources/default
+          update_taskcat: true
+
+  e2e-v1-lint-update:
+    name: End-to-end tests - @v1 - update taskcat
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+      - name: Invoke "taskcat test run --lint-disable"
+        uses: ShahradR/action-taskcat@v1
+        with:
+          commands: test run --project-root ./e2e/resources/default
+          update_taskcat: true
+          update_cfn_lint: true
+
+  e2e-v2-default:
+    name: End-to-end tests - @v2 - default
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+      - name: Invoke "taskcat test run --lint-disable"
+        uses: ShahradR/action-taskcat@v2
+        with:
+          commands: test run --project-root ./e2e/resources/default
+
+  e2e-v2-update:
+    name: End-to-end tests - @v2 - update taskcat
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+      - name: Invoke "taskcat test run --lint-disable"
+        uses: ShahradR/action-taskcat@v2
+        with:
+          commands: test run --project-root ./e2e/resources/default
+          update_taskcat: true
+
+  e2e-v2-lint-update:
+    name: End-to-end tests - @v2 - update taskcat
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+      - name: Invoke "taskcat test run --lint-disable"
+        uses: ShahradR/action-taskcat@v2
+        with:
+          commands: test run --project-root ./e2e/resources/default
+          update_taskcat: true
+          update_cfn_lint: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -112,114 +112,6 @@ jobs:
           update_taskcat: true
           update_cfn_lint: true
 
-  e2e-v1-default:
-    name: End-to-end tests - @v1 - default
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
-      - name: Invoke "taskcat test run"
-        uses: ShahradR/action-taskcat@v1
-        with:
-          commands: test run --lint-disable --project-root ./e2e/resources/default
-
-  e2e-v1-update:
-    name: End-to-end tests - @v1 - update taskcat
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
-      - name: Invoke "taskcat test run --lint-disable"
-        uses: ShahradR/action-taskcat@v1
-        with:
-          commands: test run --project-root ./e2e/resources/default
-          update_taskcat: true
-
-  e2e-v1-lint-update:
-    name: End-to-end tests - @v1 - update taskcat
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
-      - name: Invoke "taskcat test run --lint-disable"
-        uses: ShahradR/action-taskcat@v1
-        with:
-          commands: test run --project-root ./e2e/resources/default
-          update_taskcat: true
-          update_cfn_lint: true
-
-  e2e-v2-default:
-    name: End-to-end tests - @v2 - default
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
-      - name: Invoke "taskcat test run --lint-disable"
-        uses: ShahradR/action-taskcat@v2
-        with:
-          commands: test run --project-root ./e2e/resources/default
-
-  e2e-v2-update:
-    name: End-to-end tests - @v2 - update taskcat
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
-      - name: Invoke "taskcat test run --lint-disable"
-        uses: ShahradR/action-taskcat@v2
-        with:
-          commands: test run --project-root ./e2e/resources/default
-          update_taskcat: true
-
-  e2e-v2-lint-update:
-    name: End-to-end tests - @v2 - update taskcat
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
-      - name: Invoke "taskcat test run --lint-disable"
-        uses: ShahradR/action-taskcat@v2
-        with:
-          commands: test run --project-root ./e2e/resources/default
-          update_taskcat: true
-          update_cfn_lint: true
-
   vale:
     name: Run Vale
     runs-on: ubuntu-latest
@@ -235,18 +127,7 @@ jobs:
   release:
     name: Create release
     runs-on: ubuntu-latest
-    needs:
-      [
-        pre-commit,
-        tests,
-        e2e-default,
-        e2e-update,
-        e2e-lint-update,
-        e2e-v1-default,
-        e2e-v1-update,
-        e2e-v1-lint-update,
-        vale,
-      ]
+    needs: [pre-commit, tests, e2e-default, e2e-update, e2e-lint-update, vale]
     if: ${{ needs.pre-commit.result == 'success' && needs.tests.result == 'success' && needs.e2e-default.result == 'success' && needs.e2e-update.result == 'success' && needs.e2e-lint-update.result == 'success' && needs.e2e-v1-default.result == 'success' && needs.e2e-v1-update.result == 'success' && needs.e2e-v1-lint-update.result == 'success' && needs.vale.result == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Split the end-to-end tests that run the tagged versions in a separate GitHub Actions workflow, to ensure that breaking changes don't block deployments.

The new workflow is also configured to run daily, and will allow us to catch issues with the action early.

Note that the end-to-end tests that run the untagged versions (i.e.: the one in the current commit) are still required to create a release, and will run with every commit.