### PR TITLE
ci: update conditions for release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -135,9 +135,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 21
       - name: Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v4.1.1
         id: semantic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -128,7 +128,7 @@ jobs:
     name: Create release
     runs-on: ubuntu-latest
     needs: [pre-commit, tests, e2e-default, e2e-update, e2e-lint-update, vale]
-    if: ${{ needs.pre-commit.result == 'success' && needs.tests.result == 'success' && needs.e2e-default.result == 'success' && needs.e2e-update.result == 'success' && needs.e2e-lint-update.result == 'success' && needs.e2e-v1-default.result == 'success' && needs.e2e-v1-update.result == 'success' && needs.e2e-v1-lint-update.result == 'success' && needs.vale.result == 'success' }}
+    if: ${{ needs.pre-commit.result == 'success' && needs.tests.result == 'success' && needs.e2e-default.result == 'success' && needs.e2e-update.result == 'success' && needs.e2e-lint-update.result == 'success' && needs.vale.result == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
Update the conditions for the release pipeline to exclude the end-to-end tests that were split off into a separate workflow.