### PR TITLE
ci: change type for "on" key in e2e CI workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,9 +1,9 @@
 name: CI workflow
 
 on:
-  - workflow_dispatch
-  - schedule:
-      - cron: "0 18 * * *"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 18 * * *"
 
 permissions:
   checks: write


### PR DESCRIPTION
Change the type of the `on` key in the end-to-end CI workflow from a sequence to a collection, as dictated by the GitHub Actions schema.

For more details, see [Using activity types and filters with multiple events](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#using-activity-types-and-filters-with-multiple-events) in the GitHub Actions documentation.