### PR TITLE
ci: abandon v1 release support in end-to-end tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -66,60 +66,6 @@ jobs:
           update_taskcat: true
           update_cfn_lint: true
 
-  e2e-v1-default:
-    name: End-to-end tests - @v1 - default
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
-      - name: Invoke "taskcat test run"
-        uses: ShahradR/action-taskcat@v1
-        with:
-          commands: test run --lint-disable --project-root ./e2e/resources/default
-
-  e2e-v1-update:
-    name: End-to-end tests - @v1 - update taskcat
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
-      - name: Invoke "taskcat test run --lint-disable"
-        uses: ShahradR/action-taskcat@v1
-        with:
-          commands: test run --project-root ./e2e/resources/default
-          update_taskcat: true
-
-  e2e-v1-lint-update:
-    name: End-to-end tests - @v1 - update taskcat
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
-      - name: Invoke "taskcat test run --lint-disable"
-        uses: ShahradR/action-taskcat@v1
-        with:
-          commands: test run --project-root ./e2e/resources/default
-          update_taskcat: true
-          update_cfn_lint: true
-
   e2e-v2-default:
     name: End-to-end tests - @v2 - default
     runs-on: ubuntu-latest


### PR DESCRIPTION
Abandon support for this action's v1 release, considering the action was broken for an extended period of time, and the fix to resolve the PyYAML issue highlighted in #350 cannot be easily applied to the older version.

With the abandonned support, the v1 end-to-end tests are removed from the CI workflow.