### PR TITLE
ci: fix --lint-disable flag for v2 e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -78,10 +78,10 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
-      - name: Invoke "taskcat test run --lint-disable"
+      - name: Invoke "taskcat test run"
         uses: ShahradR/action-taskcat@v2
         with:
-          commands: test run --project-root ./e2e/resources/default
+          commands: test run --lint-disable --project-root ./e2e/resources/default
 
   e2e-v2-update:
     name: End-to-end tests - @v2 - update taskcat
@@ -95,10 +95,10 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
-      - name: Invoke "taskcat test run --lint-disable"
+      - name: Invoke "taskcat test run"
         uses: ShahradR/action-taskcat@v2
         with:
-          commands: test run --project-root ./e2e/resources/default
+          commands: test run --lint-disable --project-root ./e2e/resources/default
           update_taskcat: true
 
   e2e-v2-lint-update:
@@ -113,9 +113,9 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
-      - name: Invoke "taskcat test run --lint-disable"
+      - name: Invoke "taskcat test run"
         uses: ShahradR/action-taskcat@v2
         with:
-          commands: test run --project-root ./e2e/resources/default
+          commands: test run --lint-disable --project-root ./e2e/resources/default
           update_taskcat: true
           update_cfn_lint: true


### PR DESCRIPTION
Update the end-to-end tests for the @v2-tagged version of this action to include the --lint-disable flag in the taskcat invocation.

The flag was introduced in an earlier commit, but was erroneously added to the step's name, instead of the command itself.